### PR TITLE
Fixes #22

### DIFF
--- a/lwreg/standardization_lib.py
+++ b/lwreg/standardization_lib.py
@@ -5,6 +5,7 @@
 # which is included in the file LICENSE,
 
 from rdkit import Chem
+from rdkit.Chem.MolStandardize import rdMolStandardize
 
 
 class Standardization:
@@ -48,3 +49,63 @@ class PolymerCheck(Standardization):
                 return None
 
         return mol
+
+
+class RDKitSanitize(Standardization):
+    name = "rdkit_sanitize"
+    explanation = "runs the standard RDKit sanitization on the molecule"
+
+    def __call__(self, mol):
+        try:
+            Chem.SanitizeMol(mol)
+        except:
+            return None
+        return mol
+
+
+class FragmentParent(Standardization):
+    name = "fragment_parent"
+    explanation = "generates the fragment parent of the molecule"
+
+    def __call__(self, mol):
+        try:
+            res = rdMolStandardize.FragmentParent(mol)
+        except:
+            return None
+        return res
+
+
+class ChargeParent(Standardization):
+    name = "charge_parent"
+    explanation = "generates the charge parent of the molecule"
+
+    def __call__(self, mol):
+        try:
+            res = rdMolStandardize.ChargeParent(mol)
+        except:
+            return None
+        return res
+
+
+class TautomerParent(Standardization):
+    name = "tautomer_parent"
+    explanation = "generates the tautomer parent of the molecule"
+
+    def __call__(self, mol):
+        try:
+            res = rdMolStandardize.TautomerParent(mol)
+        except:
+            return None
+        return res
+
+
+class SuperParent(Standardization):
+    name = "super_parent"
+    explanation = "generates the super parent of the molecule"
+
+    def __call__(self, mol):
+        try:
+            res = rdMolStandardize.SuperParent(mol)
+        except:
+            return None
+        return res

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -72,45 +72,50 @@ class TestLWReg(unittest.TestCase):
         self.assertEqual(utils.register(smiles='CCCC1', config=self._config),
                          RegistrationFailureReasons.PARSE_FAILURE)
         self.assertEqual(utils.register(smiles='c1nccc1', config=self._config),
-                         RegistrationFailureReasons.PARSE_FAILURE)
+                         RegistrationFailureReasons.FILTERED)
 
     def testGetDelimiter(self):
-        self.assertEqual(utils._get_delimiter('test_data/test_smiles_no_delim.smi'),
-                         None)
-        self.assertEqual(utils._get_delimiter('test_data/test_smiles_no_delim_with_header.smi'),
-                         None)
-        self.assertEqual(utils._get_delimiter('test_data/test_smiles_with_header.smi'),
-                         ';')
+        self.assertEqual(
+            utils._get_delimiter('test_data/test_smiles_no_delim.smi'), None)
+        self.assertEqual(
+            utils._get_delimiter(
+                'test_data/test_smiles_no_delim_with_header.smi'), None)
+        self.assertEqual(
+            utils._get_delimiter('test_data/test_smiles_with_header.smi'), ';')
         self.assertEqual(utils._get_delimiter('test_data/test_smiles.smi'),
                          ' ')
 
     def testGetSmilesColumn(self):
-        self.assertEqual(utils._get_smiles_column('test_data/test_smiles_with_header.smi',
-                                                  delimiter=';'),
-                         1)
-        self.assertEqual(utils._get_smiles_column('test_data/test_smiles.smi',
-                                                  delimiter=' '),
-                         1)
+        self.assertEqual(
+            utils._get_smiles_column('test_data/test_smiles_with_header.smi',
+                                     delimiter=';'), 1)
+        self.assertEqual(
+            utils._get_smiles_column('test_data/test_smiles.smi',
+                                     delimiter=' '), 1)
 
     def testHasHeader(self):
-        self.assertTrue(utils._has_header('test_data/test_smiles_no_delim_with_header.smi',
-                                          delimiter=' '))
-        self.assertFalse(utils._has_header('test_data/test_smiles_no_delim.smi',
-                                           delimiter=' '))
-        self.assertTrue(utils._has_header('test_data/test_smiles_with_header.smi',
-                                          delimiter=','))
-        self.assertFalse(utils._has_header('test_data/test_smiles.smi',
-                                           delimiter=' '))
+        self.assertTrue(
+            utils._has_header('test_data/test_smiles_no_delim_with_header.smi',
+                              delimiter=' '))
+        self.assertFalse(
+            utils._has_header('test_data/test_smiles_no_delim.smi',
+                              delimiter=' '))
+        self.assertTrue(
+            utils._has_header('test_data/test_smiles_with_header.smi',
+                              delimiter=','))
+        self.assertFalse(
+            utils._has_header('test_data/test_smiles.smi', delimiter=' '))
 
     def testGetMolsFromSmilesfile(self):
-        filenames = ['test_data/test_smiles_no_delim.smi',
-                     'test_data/test_smiles_no_delim_with_header.smi',
-                     'test_data/test_smiles_with_header.smi',
-                     'test_data/test_smiles.smi']
+        filenames = [
+            'test_data/test_smiles_no_delim.smi',
+            'test_data/test_smiles_no_delim_with_header.smi',
+            'test_data/test_smiles_with_header.smi',
+            'test_data/test_smiles.smi'
+        ]
         for filename in filenames:
             mols = utils._get_mols_from_smilesfile(filename)
-            self.assertEqual(len(mols),
-                             6)
+            self.assertEqual(len(mols), 6)
 
     def testBulkRegister(self):
         utils.initdb(config=self._config, confirm=True)
@@ -122,21 +127,24 @@ class TestLWReg(unittest.TestCase):
                          (1, 2, RegistrationFailureReasons.PARSE_FAILURE,
                           RegistrationFailureReasons.PARSE_FAILURE,
                           RegistrationFailureReasons.DUPLICATE, 3))
-        self.assertEqual(utils.bulk_register(sdfile='test_data/test_molecules.sdf',
-                                             config=self._config),
-                         (4, 5, 6, 7, 8, 9))
-        self.assertEqual(utils.bulk_register(smilesfile='test_data/test_smiles_no_delim_with_header.smi',
-                                             config=self._config),
-                         (10, 11, 12, 13, 14, 15))
-        self.assertEqual(utils.bulk_register(smilesfile='test_data/test_smiles_with_header.smi',
-                                             config=self._config),
-                         (16, 17, 18, 19, 20, 21))
-        self.assertEqual(utils.bulk_register(smilesfile='test_data/test_smiles_no_delim.smi',
-                                             config=self._config),
-                         (22, 23, 24, 25, 26, 27))
-        self.assertEqual(utils.bulk_register(smilesfile='test_data/test_smiles.smi',
-                                             config=self._config),
-                         (28, 29, 30, 31, 32, 33))
+        self.assertEqual(
+            utils.bulk_register(sdfile='test_data/test_molecules.sdf',
+                                config=self._config), (4, 5, 6, 7, 8, 9))
+        self.assertEqual(
+            utils.bulk_register(
+                smilesfile='test_data/test_smiles_no_delim_with_header.smi',
+                config=self._config), (10, 11, 12, 13, 14, 15))
+        self.assertEqual(
+            utils.bulk_register(
+                smilesfile='test_data/test_smiles_with_header.smi',
+                config=self._config), (16, 17, 18, 19, 20, 21))
+        self.assertEqual(
+            utils.bulk_register(
+                smilesfile='test_data/test_smiles_no_delim.smi',
+                config=self._config), (22, 23, 24, 25, 26, 27))
+        self.assertEqual(
+            utils.bulk_register(smilesfile='test_data/test_smiles.smi',
+                                config=self._config), (28, 29, 30, 31, 32, 33))
 
     def testBulkRegisterAllowDupes(self):
         utils.initdb(config=self._config, confirm=True)
@@ -150,7 +158,6 @@ class TestLWReg(unittest.TestCase):
                                 config=self._config),
             (1, 2, RegistrationFailureReasons.PARSE_FAILURE,
              RegistrationFailureReasons.PARSE_FAILURE, 1, 3))
-
 
     def testQuery(self):
         self.baseRegister()
@@ -232,7 +239,8 @@ class TestLWReg(unittest.TestCase):
 
         utils.initdb(config=lconfig, confirm=True)
         self.assertEqual(utils.register(smiles='CCCO', config=lconfig), 1)
-        self.assertIsNone(utils.register(smiles='CCC', config=lconfig))
+        self.assertEqual(utils.register(smiles='CCC', config=lconfig),
+                         RegistrationFailureReasons.FILTERED)
 
         utils.initdb(config=lconfig, confirm=True)
         checker = standardization_lib.OverlappingAtomsCheck()
@@ -240,7 +248,8 @@ class TestLWReg(unittest.TestCase):
         self.assertEqual(
             utils.register(smiles='CC |(0,0,;0,1,)|', config=lconfig), 1)
         self.assertEqual(
-            utils.register(smiles='CO |(0,0,;0,0,)|', config=lconfig), None)
+            utils.register(smiles='CO |(0,0,;0,0,)|', config=lconfig),
+            RegistrationFailureReasons.FILTERED)
 
         def hasAnOxygen(mol):
             for atom in mol.GetAtoms():
@@ -252,19 +261,23 @@ class TestLWReg(unittest.TestCase):
         # chaining standardization functions
         utils.initdb(config=lconfig, confirm=True)
         lconfig['standardization'] = [evenAtomCount, hasAnOxygen]
-        self.assertEqual(utils.register(smiles='CC', config=lconfig), None)
+        self.assertEqual(utils.register(smiles='CC', config=lconfig),
+                         RegistrationFailureReasons.FILTERED)
         self.assertEqual(utils.register(smiles='CO', config=lconfig), 1)
-        self.assertEqual(utils.register(smiles='CCO', config=lconfig), None)
+        self.assertEqual(utils.register(smiles='CCO', config=lconfig),
+                         RegistrationFailureReasons.FILTERED)
 
         # ----------------------
         # mixing standardization options and functions
         utils.initdb(config=lconfig, confirm=True)
         lconfig['standardization'] = ('fragment', evenAtomCount, hasAnOxygen)
-        self.assertEqual(utils.register(smiles='CC', config=lconfig), None)
+        self.assertEqual(utils.register(smiles='CC', config=lconfig),
+                         RegistrationFailureReasons.FILTERED)
         self.assertEqual(utils.register(smiles='CO', config=lconfig), 1)
         self.assertEqual(utils.register(smiles='C[O-].[Na]', config=lconfig),
                          2)
-        self.assertEqual(utils.register(smiles='CCO', config=lconfig), None)
+        self.assertEqual(utils.register(smiles='CCO', config=lconfig),
+                         RegistrationFailureReasons.FILTERED)
 
     def testStandardizationLibCheckers(self):
         lconfig = self._config.copy()
@@ -275,13 +288,15 @@ class TestLWReg(unittest.TestCase):
         self.assertEqual(
             utils.register(smiles='CC |(0,0,;0,1,)|', config=lconfig), 1)
         self.assertEqual(
-            utils.register(smiles='CO |(0,0,;0,0,)|', config=lconfig), None)
+            utils.register(smiles='CO |(0,0,;0,0,)|', config=lconfig),
+            RegistrationFailureReasons.FILTERED)
 
         checker = standardization_lib.PolymerCheck()
         lconfig['standardization'] = checker
         self.assertEqual(
             utils.register(smiles='*-CO-* |$star_e;;;star_e$,Sg:n:1,2::ht|',
-                           config=lconfig), None)
+                           config=lconfig),
+            RegistrationFailureReasons.FILTERED)
         self.assertEqual(
             utils.register(molblock='''
   Mrv2305 05112307022D          
@@ -349,7 +364,6 @@ class TestLWRegPSQL(TestLWReg):
 
 
 class TestStandardizationLabels(unittest.TestCase):
-
     def testStandards(self):
         cfg = utils.defaultConfig()
         for k in utils.standardizationOptions:
@@ -366,7 +380,6 @@ class TestStandardizationLabels(unittest.TestCase):
             self.assertEqual(lbl, '|'.join(cl))
 
     def testOthers(self):
-
         def func1(x):
             pass
 


### PR DESCRIPTION
Changes here:
- Do not sanitize molecules on reading
- Add simple "sanitize" standardizer
- Mols which fail sanitization are now tagged as FILTERED, not PARSE_FAILURE 
- Move default standardizations to standardization_lib