### PR TITLE
Make initdb safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ ERROR:root:Compound already registered
 ```
 In [1]: import lwreg
 
-In [3]: lwreg.initdb(confirm=True)
+In [3]: lwreg.initdb()
+This will destroy any existing information in the registration database.
+  are you sure? [yes/no]: yes
 Out[3]: True
 
 In [4]: lwreg.register(smiles='CCO')

--- a/lwreg/lwreg.py
+++ b/lwreg/lwreg.py
@@ -29,7 +29,7 @@ def initdb(confirm='no'):
     if confirm != 'yes':
         click.echo("initdb not confirmed, aborting")
         return
-    utils.initdb(confirm=True)
+    utils._initdb(confirm=True)
 
 
 @cli.command()

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -26,7 +26,7 @@ if psycopg2:
     # we have the connector for postgresql. Is there a server running?
     cfg = utils.defaultConfig()
     cfg['dbname'] = 'lwreg_tests'
-    cfg['host'] = 'localhost'
+    #cfg['host'] = 'localhost'
     cfg['dbtype'] = 'postgresql'
     try:
         cn = utils._connect(config=cfg)
@@ -45,7 +45,7 @@ class TestLWReg(unittest.TestCase):
 
     def baseRegister(self):
         smis = ('CC[C@H](F)Cl', 'CC[C@@H](F)Cl', 'CCC(F)Cl', 'CC(F)(Cl)C')
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         for smi in smis:
             utils.register(smiles=smi, config=self._config)
         mols = [Chem.MolFromSmiles(x) for x in ('Cc1[nH]ncc1', 'Cc1n[nH]cc1')]
@@ -53,7 +53,7 @@ class TestLWReg(unittest.TestCase):
             utils.register(mol=mol, config=self._config)
 
     def testRegister(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         self.assertEqual(utils.register(smiles='CCC', config=self._config), 1)
         self.assertEqual(utils.register(smiles='CCCO', config=self._config), 2)
         self.assertRaises(
@@ -122,7 +122,7 @@ class TestLWReg(unittest.TestCase):
             self.assertEqual(len(mols), 6)
 
     def testBulkRegister(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         mols = [
             Chem.MolFromSmiles(x)
             for x in ('CCC', 'CCCO', 'C1', 'c1cc1', 'CCC', 'C1CC1')
@@ -175,7 +175,7 @@ class TestLWReg(unittest.TestCase):
         self.assertEqual(res.count(RegistrationFailureReasons.DUPLICATE), 0)
 
     def testBulkRegisterAllowDupes(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         mols = [
             Chem.MolFromSmiles(x)
             for x in ('CCC', 'CCCO', 'C1', 'c1cc1', 'CCC', 'C1CC1')
@@ -244,14 +244,14 @@ class TestLWReg(unittest.TestCase):
     def testStandardizationOptions(self):
         lconfig = self._config.copy()
         lconfig['standardization'] = 'charge'
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         self.assertEqual(utils.register(smiles='CCCO', config=lconfig), 1)
         self.assertRaises(
             self.integrityError,
             lambda: utils.register(smiles='CCC[O-]', config=lconfig))
 
         lconfig['standardization'] = 'tautomer'
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         self.assertEqual(utils.register(smiles='Cc1[nH]ncc1', config=lconfig),
                          1)
         self.assertRaises(
@@ -269,12 +269,12 @@ class TestLWReg(unittest.TestCase):
         # Silly example which only accepts even numbers of atoms
         lconfig['standardization'] = evenAtomCount
 
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         self.assertEqual(utils.register(smiles='CCCO', config=lconfig), 1)
         self.assertEqual(utils.register(smiles='CCC', config=lconfig),
                          RegistrationFailureReasons.FILTERED)
 
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         checker = standardization_lib.OverlappingAtomsCheck()
         lconfig['standardization'] = checker
         self.assertEqual(
@@ -291,7 +291,7 @@ class TestLWReg(unittest.TestCase):
 
         # ----------------------
         # chaining standardization functions
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         lconfig['standardization'] = [evenAtomCount, hasAnOxygen]
         self.assertEqual(utils.register(smiles='CC', config=lconfig),
                          RegistrationFailureReasons.FILTERED)
@@ -301,7 +301,7 @@ class TestLWReg(unittest.TestCase):
 
         # ----------------------
         # mixing standardization options and functions
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         lconfig['standardization'] = ('fragment', evenAtomCount, hasAnOxygen)
         self.assertEqual(utils.register(smiles='CC', config=lconfig),
                          RegistrationFailureReasons.FILTERED)
@@ -314,7 +314,7 @@ class TestLWReg(unittest.TestCase):
     def testStandardizationLibCheckers(self):
         lconfig = self._config.copy()
 
-        utils.initdb(config=lconfig, confirm=True)
+        utils._initdb(config=lconfig, confirm=True)
         checker = standardization_lib.OverlappingAtomsCheck()
         lconfig['standardization'] = checker
         self.assertEqual(
@@ -367,7 +367,7 @@ class TestLWRegTautomerv2(unittest.TestCase):
         self._config['useTautomerHashv2'] = 1
 
     def testRegister(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         self.assertEqual(utils.register(smiles='CCC', config=self._config), 1)
         self.assertEqual(utils.register(smiles='CCCO', config=self._config), 2)
         self.assertEqual(utils.register(smiles='CC=CO', config=self._config),
@@ -436,7 +436,7 @@ class TestStandardizationLabels(unittest.TestCase):
     def testRecording(self):
         cfg = utils.defaultConfig()
         cfg['dbname'] = 'foo.sqlt'
-        utils.initdb(config=cfg, confirm=True)
+        utils._initdb(config=cfg, confirm=True)
         self.assertEqual(utils.register(smiles='CCO', config=cfg), 1)
         self.assertEqual(utils.register(smiles='CCOC', config=cfg), 2)
         oac = standardization_lib.OverlappingAtomsCheck()
@@ -464,7 +464,7 @@ class TestConformerHashes(unittest.TestCase):
         rdDistGeom.EmbedMolecule(self._mol2, randomSeed=0xf00d + 1)
 
     def testConformerDupes(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         self.assertEqual(utils.register(mol=self._mol1, config=self._config),
                          1)
         self.assertEqual(utils.register(mol=self._mol2, config=self._config),
@@ -492,7 +492,7 @@ class TestRegisterConformers(unittest.TestCase):
         rdDistGeom.EmbedMolecule(self._mol3, randomSeed=0xf00d)
 
     def testConformerDupes(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         self.assertEqual(utils.register(mol=self._mol1, config=self._config),
                          (1, 1))
         self.assertEqual(utils.register(mol=self._mol2, config=self._config),
@@ -513,7 +513,7 @@ class TestRegisterConformers(unittest.TestCase):
                            fail_on_duplicate=False), (1, 1))
 
     def testBulkConformers(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         aorder = list(range(self._mol1.GetNumAtoms()))
         random.shuffle(aorder)
         nmol = Chem.RenumberAtoms(self._mol1, aorder)
@@ -529,7 +529,7 @@ class TestRegisterConformers(unittest.TestCase):
             expected[self._config['dbtype']])
 
     def testNoConformers(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         with self.assertRaises(ValueError):
             utils.register(smiles='c1ccccc1', config=self._config)
 
@@ -547,7 +547,7 @@ class TestRegisterConformers(unittest.TestCase):
             utils.register(mol=m, config=self._config)
 
     def testMultiConfMolecule(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
 
         mol = Chem.Mol(self._mol1)
         cids = rdDistGeom.EmbedMultipleConfs(mol, 10, randomSeed=0xf00d)
@@ -574,7 +574,7 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertEqual(len(set([mrn for mrn, cid in rres])), 1)
 
         # make sure we can still fail on duplicate conformers:
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         with self.assertRaises(self.integrityError):
             utils.register_multiple_conformers(mol=mol,
                                                fail_on_duplicate=True,
@@ -582,7 +582,7 @@ class TestRegisterConformers(unittest.TestCase):
 
     def testConformerQuery(self):
         ''' querying using a molecule which has conformers '''
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol3),
                                      config=self._config)
         self.assertEqual(
@@ -603,7 +603,7 @@ class TestRegisterConformers(unittest.TestCase):
 
     def testConformerRetrieve(self):
         ''' querying using a molecule which has conformers '''
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
                                      config=self._config)
 
@@ -614,7 +614,7 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertTrue('M  END' in res[1][2])
 
     def testConformerQueryById(self):
-        utils.initdb(config=self._config, confirm=True)
+        utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
                                      config=self._config)
         mrns, cids = zip(*regids)

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -953,8 +953,13 @@ def _initdb(config=None, confirm=False):
     return True
 
 def initdb(config=None):
-    
-
+    print("This will destroy any existing information in the registration database.")
+    response = input("  are you sure? [yes/no]: ")
+    if response=='yes':
+        return _initdb(config=config, confirm=True)
+    else:
+        print("cancelled")
+        return False
 
 
 

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -953,9 +953,17 @@ def _initdb(config=None, confirm=False):
     return True
 
 def initdb(config=None):
+    """ initializes the registration database    
+
+    NOTE you will be prompted to confirm this action since this call can destroy any 
+    existing information in the registration database
+
+    Keyword arguments:
+    config  -- configuration dict
+    """
     print("This will destroy any existing information in the registration database.")
     response = input("  are you sure? [yes/no]: ")
-    if response=='yes':
+    if response == 'yes':
         return _initdb(config=config, confirm=True)
     else:
         print("cancelled")

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -891,7 +891,7 @@ def _registerMetadata(curs, config):
         ('rdkitVersion', rdkit.__version__))
 
 
-def initdb(config=None, confirm=False):
+def _initdb(config=None, confirm=False):
     """ initializes the registration database    
 
     NOTE that this call destroys any existing information in the registration database
@@ -951,6 +951,11 @@ def initdb(config=None, confirm=False):
 
     cn.commit()
     return True
+
+def initdb(config=None):
+    
+
+
 
 
 FORBIDDEN_COMBINATIONS = [{


### PR DESCRIPTION
The previous API made it too easy to accidentally trash an entire database.

This fixes that by renaming the current function `initdb()` to `_initdb()` (so it can still be called from scripts and other code) and replaces it with something which prompts the user for confirmation.


