### PR TITLE
add a conformer standardization pipeline step

### DIFF
--- a/lwreg/standardization_lib.py
+++ b/lwreg/standardization_lib.py
@@ -38,11 +38,12 @@ class RemoveHs(Standardization):
 
 class CanonicalizeOrientation(Standardization):
     name = "canonicalize_orientation"
-    explanation = "canonicalizes the orientation of the molecule's first conformer (if present and 3D)"
+    explanation = "canonicalizes the orientation of the molecule's 3D conformers (if present)"
 
     def __call__(self, mol):
-        if mol.GetNumConformers() and mol.GetConformer().Is3D():
-            rdMolTransforms.CanonicalizeConformer(mol.GetConformer())
+        for conf in mol.GetConformers():
+            if conf.Is3D():
+                rdMolTransforms.CanonicalizeConformer(conf)
         return mol
 
 

--- a/lwreg/standardization_lib.py
+++ b/lwreg/standardization_lib.py
@@ -6,6 +6,7 @@
 
 from rdkit import Chem
 from rdkit.Chem.MolStandardize import rdMolStandardize
+from rdkit.Chem import rdMolTransforms
 
 
 class Standardization:
@@ -34,6 +35,15 @@ class RemoveHs(Standardization):
     def __call__(self, mol):
         return Chem.RemoveHs(mol)
 
+
+class CanonicalizeOrientation(Standardization):
+    name = "canonicalize_orientation"
+    explanation = "canonicalizes the orientation of the molecule's first conformer (if present and 3D)"
+
+    def __call__(self, mol):
+        if mol.GetNumConformers() and mol.GetConformer().Is3D():
+            rdMolTransforms.CanonicalizeConformer(mol.GetConformer())
+        return mol
 
 
 class OverlappingAtomsCheck(Standardization):

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -912,7 +912,6 @@ class TestRegisterConformers(unittest.TestCase):
             pi = conf.GetAtomPosition(i)
             conf.SetAtomPosition(i, (pi.y, pi.x, pi.z + 1.5))
         cp.AddConformer(self._mol1.GetConformer(), assignId=True)
-        print('!!!!!!!!!!!!!!!!!!!')
         self.assertRaises(
             self.integrityError, lambda: utils.register_multiple_conformers(
                 mol=cp, fail_on_duplicate=True, config=cfg))

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -900,6 +900,23 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertRaises(self.integrityError,
                           lambda: utils.register(mol=cp, config=cfg))
 
+    def testMultiConformerStandardization(self):
+        cfg = self._config.copy()
+        cfg['standardization'] = [
+            standardization_lib.CanonicalizeOrientation()
+        ]
+        utils._initdb(config=cfg, confirm=True)
+        cp = Chem.Mol(self._mol1)
+        conf = cp.GetConformer()
+        for i in range(conf.GetNumAtoms()):
+            pi = conf.GetAtomPosition(i)
+            conf.SetAtomPosition(i, (pi.y, pi.x, pi.z + 1.5))
+        cp.AddConformer(self._mol1.GetConformer(), assignId=True)
+        print('!!!!!!!!!!!!!!!!!!!')
+        self.assertRaises(
+            self.integrityError, lambda: utils.register_multiple_conformers(
+                mol=cp, fail_on_duplicate=True, config=cfg))
+
 
 @unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
 class TestRegisterConformersPSQL(TestRegisterConformers):


### PR DESCRIPTION
This allows (optional) translationally and rotationally invariant registration of conformers.