### PR TITLE
Verbosity and error handling improvements in bulk_register

### DIFF
--- a/demos/02_computational_experiment_1.ipynb
+++ b/demos/02_computational_experiment_1.ipynb
@@ -314,7 +314,7 @@
    ],
    "source": [
     "# now bulk register. We want to also collect IDs of compounds which were already registered.\n",
-    "reg_ids = lwreg.bulk_register(mols=ms,failOnDuplicate=False)\n",
+    "reg_ids = lwreg.bulk_register(mols=ms,fail_on_duplicate=False)\n",
     "reg_ids = set(reg_ids)\n",
     "print(f'Registered {len(reg_ids)} unique compounds.')"
    ]

--- a/demos/03_computational_experiment_2.ipynb
+++ b/demos/03_computational_experiment_2.ipynb
@@ -380,7 +380,7 @@
    ],
    "source": [
     "# now bulk register. We want to also collect IDs of compounds which were already registered.\n",
-    "reg_ids = lwreg.bulk_register(mols=ms_3d,failOnDuplicate=False)\n",
+    "reg_ids = lwreg.bulk_register(mols=ms_3d,fail_on_duplicate=False)\n",
     "print(f'Registered {len(reg_ids)} unique conformers.')"
    ]
   },

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - ipython-sql
   - sqlalchemy=1.4
   - pytest
+  - tqdm

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -198,7 +198,7 @@ class TestLWReg(unittest.TestCase):
         ]
 
         res = utils.bulk_register(mols=mols,
-                                  failOnDuplicate=False,
+                                  fail_on_duplicate=False,
                                   config=self._config)
         self.assertEqual(len(res), 6)
         self.assertEqual(res[2], RegistrationFailureReasons.PARSE_FAILURE)
@@ -651,7 +651,7 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertEqual(
             utils.bulk_register(mols=(self._mol1, self._mol2, nmol,
                                       self._mol3),
-                                failOnDuplicate=False,
+                                fail_on_duplicate=False,
                                 config=self._config),
             expected[self._config['dbtype']])
         self.assertEqual(utils.registration_counts(config=self._config),

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -51,6 +51,7 @@ _defaultConfig = {
 }
 
 from rdkit.Chem.RegistrationHash import HashLayer
+from rdkit.Chem import KekulizeException
 
 
 class RegistrationFailureReasons(enum.Enum):
@@ -483,7 +484,10 @@ def _register_mol(tpl,
             Chem.AssignStereochemistryFrom3D(sMol, confId)
         if sMol is None:
             return None, None
-        molb = Chem.MolToV3KMolBlock(sMol, confId=confId)
+        try:
+            molb = Chem.MolToV3KMolBlock(sMol, confId=confId)
+        except KekulizeException:
+            return None, None
 
         mhash, layers = hash_mol(sMol, escape=escape, config=config)
 

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -814,7 +814,7 @@ def bulk_register(config=None,
     )
     def_rdkit_version_label = curs.fetchone()[0]
 
-    for mol in mols:
+    for mol_idx, mol in enumerate(mols):
         if mol is None:
             res.append(RegistrationFailureReasons.PARSE_FAILURE)
             continue
@@ -843,6 +843,8 @@ def bulk_register(config=None,
                 res.append((mrn, conf_id))
         except _violations:
             res.append(RegistrationFailureReasons.DUPLICATE)
+        except Exception as e:
+            raise Exception(f'Error registering molecule with index: {mol_idx}') from e
     if not no_verbose:
         print(res)
     return tuple(res)

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -817,9 +817,9 @@ def bulk_register(config=None,
         f"select value from {registrationMetadataTableName} where key='rdkitVersion'"
     )
     def_rdkit_version_label = curs.fetchone()[0]
-
-    progress_count = len(mols)
-    start_time = time()
+    if show_progress:
+        progress_count = len(mols)
+        start_time = time()
     for mol_idx, mol in enumerate(mols):
         if show_progress:
             _show_progress_bar(mol_idx+1, progress_count, start_time, prefix='Registering molecules: ')

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -851,6 +851,13 @@ def bulk_register(config=None,
                 res.append((mrn, conf_id))
         except _violations:
             res.append(RegistrationFailureReasons.DUPLICATE)
+        except psycopg2.errors.ProgramLimitExceeded as e:
+            # check if the exception is ProgramLimitExceeded and config has a
+            # 'registerConformers'==1, if so print user friendly message
+            if _lookupWithDefault(config, "registerConformers"):
+                raise Exception(f"Error registering molecule with index: {mol_idx}.\nProblem might be due to the length of the conformer hash.\nTry reducing the 'numConformerDigits' or the number of atoms in the molecule") from e
+            else:
+                raise Exception(f'Error registering molecule with index: {mol_idx}') from e
         except Exception as e:
             raise Exception(f'Error registering molecule with index: {mol_idx}') from e
     if not no_verbose:

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -439,7 +439,7 @@ def _register_mol(tpl,
                   cn,
                   curs,
                   config,
-                  failOnDuplicate,
+                  fail_on_duplicate,
                   def_rdkit_version_label=None,
                   def_std_label=None,
                   confId=-1,
@@ -525,7 +525,7 @@ def _register_mol(tpl,
         cn.commit()
     except _violations:
         cn.rollback()
-        if failOnDuplicate and not (registerConformers
+        if fail_on_duplicate and not (registerConformers
                                     and sMol.GetNumConformers()):
             raise
         else:
@@ -547,7 +547,7 @@ def _register_mol(tpl,
                                           cn,
                                           curs,
                                           config,
-                                          failOnDuplicate,
+                                          fail_on_duplicate,
                                           confId=confId)
 
     return mrn, conf_id

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -395,7 +395,7 @@ def _register_one_conformer(mrn,
                             cn,
                             curs,
                             config,
-                            failOnDuplicate,
+                            fail_on_duplicate,
                             confId=-1):
     try:
         chash = _get_conformer_hash(sMol,
@@ -422,7 +422,7 @@ def _register_one_conformer(mrn,
         cn.commit()
     except _violations:
         cn.rollback()
-        if failOnDuplicate:
+        if fail_on_duplicate:
             raise
         else:
             curs.execute(
@@ -636,7 +636,7 @@ def register(config=None,
     molblock   -- MOL or SDF block
     smiles     -- smiles
     escape     -- the escape layer
-    failOnDuplicate -- if true then an exception is raised when trying to register a duplicate
+    fail_on_duplicate -- if true then an exception is raised when trying to register a duplicate
     confId     -- the conformer ID to use when in registerConformers mode
     no_verbose -- if this is False then the registry number will be printed
     """
@@ -688,7 +688,7 @@ def register_multiple_conformers(config=None,
     config     -- configuration dict
     mol        -- RDKit molecule object (must have at least one conformer)
     escape     -- the escape layer
-    failOnDuplicate -- if true then an exception is raised when trying to register a duplicate
+    fail_on_duplicate -- if true then an exception is raised when trying to register a duplicate
     no_verbose -- if this is False then the registry number will be printed
     """
     if not config:
@@ -774,7 +774,7 @@ def bulk_register(config=None,
     The result tuple includes a single entry for each molecule in the input.
     That entry can be one of the following:
       - the registry number (molregno) of the registered molecule
-      - RegistrationFailureReasons.DUPLICATE if failOnDuplicate is True and a
+      - RegistrationFailureReasons.DUPLICATE if fail_on_duplicate is True and a
         molecule is a duplicate
       - RegistrationFalureReasons.PARSE_FAILURE if there was a problem processing
         the molecule 
@@ -785,8 +785,8 @@ def bulk_register(config=None,
     config         -- configuration dict
     mols           -- an iterable of RDKit molecule objects
     sdfile         -- SDF filename
-    escapeProperty -- the molecule property to use as the escape layer
-    failOnDuplicate -- if true then RegistraionFailureReasons.DUPLICATE will be returned 
+    escape_property -- the molecule property to use as the escape layer
+    fail_on_duplicate -- if true then RegistraionFailureReasons.DUPLICATE will be returned 
                        for each already-registered molecule, otherwise the already existing
                        structure ID will be returned
     no_verbose     -- if this is False then the registry numbers will be printed

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -14,6 +14,8 @@ import sqlite3
 import enum
 from . import standardization_lib
 import logging
+from time import time
+import sys
 
 _violations = (sqlite3.IntegrityError, )
 try:
@@ -760,7 +762,8 @@ def bulk_register(config=None,
                   smilesfile=None,
                   escapeProperty=None,
                   failOnDuplicate=True,
-                  no_verbose=True):
+                  no_verbose=True,
+                  show_progress=False):
     """ registers multiple new molecules, assuming they don't already exist,
     and returns the new registry numbers (molregno)
     
@@ -783,6 +786,7 @@ def bulk_register(config=None,
                        for each already-registered molecule, otherwise the already existing
                        structure ID will be returned
     no_verbose     -- if this is False then the registry numbers will be printed
+    show_progress   -- if this is True then a progress bar will be shown for the molecules
     """
 
     if mols:
@@ -814,7 +818,11 @@ def bulk_register(config=None,
     )
     def_rdkit_version_label = curs.fetchone()[0]
 
+    progress_count = len(mols)
+    start_time = time()
     for mol_idx, mol in enumerate(mols):
+        if show_progress:
+            _show_progress_bar(mol_idx+1, progress_count, start_time, prefix='Registering molecules: ')
         if mol is None:
             res.append(RegistrationFailureReasons.PARSE_FAILURE)
             continue
@@ -1238,3 +1246,20 @@ def _check_config(config):
 
     if config.get("dbtype","sqlite3") not in ('sqlite3', 'postgresql'):
         raise ValueError("Possible values for dbtype are sqlite3 and postgresql")
+    
+def _show_progress_bar(j, count, start_time, size=60, prefix='', out=sys.stdout):
+        ''' A simple progress bar for the console to keep track of long running processes
+
+        Keyword arguments:
+        j          -- the current iteration number (e.g. the molecule index in a list of molecules)
+        count      -- the total number of iterations (e.g. the total number of molecules to process)
+        start_time -- the time the process started
+        size       -- the size of the progress bar (default 60)
+        prefix     -- a string to prepend to the progress bar (default '')
+        out        -- the output stream to write the progress bar to (default sys.stdout)
+        '''
+        x = int(size*j/count)
+        remaining = ((time() - start_time) / j) * (count - j)
+        mins, sec = divmod(remaining, 60)
+        time_str = f"{int(mins):02}:{sec:05.2f}"
+        print(f"{prefix}[{u'█'*x}{('.'*(size-x))}] {j}/{count} ETA={time_str}", end='\r', file=out, flush=True)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ conda_deps =
 conda_channels =
     conda-forge
 commands = 
-    conda install -q -c conda-forge rdkit>=2023.03.1 postgresql psycopg2
+    conda install -q -c conda-forge rdkit>=2023.03.1 postgresql psycopg2 tqdm
     pip install .
     # init database cluster
     initdb -D /tmp/testingdb

--- a/tutorial/Machine learning experiment.ipynb
+++ b/tutorial/Machine learning experiment.ipynb
@@ -340,7 +340,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mrns = lwreg.bulk_register(mols=df.mol.to_list(),failOnDuplicate=False)"
+    "mrns = lwreg.bulk_register(mols=df.mol.to_list(),fail_on_duplicate=False)"
    ]
   },
   {
@@ -390,7 +390,7 @@
     "simpd_name = 'CHEMBL217-1'\n",
     "ds = catalog[simpd_name]\n",
     "df = ds.read()\n",
-    "mrns = lwreg.bulk_register(mols=df.mol.to_list(),failOnDuplicate=False)\n",
+    "mrns = lwreg.bulk_register(mols=df.mol.to_list(),fail_on_duplicate=False)\n",
     "chembl_target = ds.metadata[\"url\"].split(\"/\")[-2]\n",
     "ds_uid = str(uuid.uuid4())\n",
     "cn = utils.connect(config=config)\n",


### PR DESCRIPTION
Multiple small improvements to the verbosity and error prints in the function bulk_register

1. A progress bar for bulk_register
    - A lightweight `tqdm` bar function is added
    - The progress bar is by default turned off and can be activated for long jobs, to get some ETA estimations
2. Changes to function arguments for consistent snake case naming
3. Catch kekulize error in MolToV3KMolBlock