### PR TITLE
Fix/remove secrets from metadata

### DIFF
--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -965,7 +965,7 @@ class TestRegisterConformersPSQL(TestRegisterConformers):
         with utils.connect(self._config).cursor() as cursor:
             cursor.execute('select * from registration_metadata;')
             keys = set(v[0] for v in cursor.fetchall())
-            assert not any(v in keys for v in ('user', 'password'))
+            self.assertFalse(any(v in keys for v in ('user', 'password'))) 
     
     def testNoSecretsInConfig(self):
         """Make sure configure_from_database isn't retrieveing accidentaly stored secrets."""
@@ -980,7 +980,7 @@ class TestRegisterConformersPSQL(TestRegisterConformers):
             dbname = self._config['dbname'],
             dbtype= self._config['dbtype']
         )        
-        assert not any(v in config_from_database for v in ('user', 'password'))
+        self.assertFalse(any(v in config_from_database for v in ('user', 'password'))) 
 
 if __name__ == '__main__':
     unittest.main()

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -3,6 +3,7 @@
 # This file is part of lwreg.
 # The contents are covered by the terms of the MIT license
 # which is included in the file LICENSE,
+import os
 import pwd
 import time
 from datetime import datetime, timedelta

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -3,7 +3,7 @@
 # This file is part of lwreg.
 # The contents are covered by the terms of the MIT license
 # which is included in the file LICENSE,
-import os
+import pwd
 import time
 from datetime import datetime, timedelta
 import unittest
@@ -952,10 +952,11 @@ class TestRegisterConformersPSQL(TestRegisterConformers):
 
     def setUp(self):
         super(TestRegisterConformersPSQL, self).setUp()
+        getlogin = lambda: pwd.getpwuid(os.getuid())[0]
         self._config['dbname'] = 'lwreg_tests'
         self._config['dbtype'] = 'postgresql'
         self._config['password'] = 'testpw'
-        self._config['user'] = os.getlogin()
+        self._config['user'] = getlogin()
 
     def testNoSecretsInRegistrationMetadata(self):
         """Make sure initdb is not storing any secrets."""

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -139,7 +139,7 @@ def configure_from_database(dbname=None,
     curs.execute(f'select * from {registrationMetadataTableName}')
     rows = curs.fetchall()
     for k, v in rows:
-        if k == 'rdkitVersion':
+        if k in ('rdkitVersion', 'user', 'password'):
             continue
         try:
             v = int(v)
@@ -1139,7 +1139,7 @@ def _registerMetadata(curs, config):
     dc.update(config)
     dc['standardization'] = _get_standardization_label(dc)
     for k, v in dc.items():
-        if k == 'connection':
+        if k in ('connection', 'user', 'password'):
             continue
         curs.execute(
             _replace_placeholders(


### PR DESCRIPTION
Two changes regarding secret handling in the config:
- Make sure secrets are not stored in the `registration_metadata` table when calling `utils.initdb(...)`
- Do not add previously stored secrets to the config dict when calling `utils.configure_from_database(...)`