### PR TITLE
add db_utils

### DIFF
--- a/lwreg/db_utils.py
+++ b/lwreg/db_utils.py
@@ -58,7 +58,10 @@ def populate_rdkit_schema(config, force=False):
     curs.execute(f"create schema if not exists {rdkit_schema_name}")
     curs.execute(f"drop table if exists {rdkit_schema_name}.mols cascade")
     curs.execute(
-        f"select molregno, mol_from_ctab(molblock::cstring,false) m into {rdkit_schema_name}.mols from {lwreg_schema_name}.molblocks"
+        f"create table {rdkit_schema_name}.mols (molregno integer not null unique references {lwreg_schema_name}.hashes (molregno), m mol)"
+    )
+    curs.execute(
+        f"insert into {rdkit_schema_name}.mols select molregno, mol_from_ctab(molblock::cstring,false) m from {lwreg_schema_name}.molblocks"
     )
     curs.execute(
         f'create index {rdkit_schema_name}_molidx on {rdkit_schema_name}.mols using gist(m)'

--- a/lwreg/db_utils.py
+++ b/lwreg/db_utils.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2022-2025 Greg Landrum and other lwreg contributors
+# All rights reserved
+# This file is part of lwreg.
+# The contents are covered by the terms of the MIT license
+# which is included in the file LICENSE,
+
+from . import utils
+
+import logging
+try:
+    import psycopg2
+except ImportError:
+    psycopg2 = None
+    logging.INFO("psycopg2 not available, RDKit cartridge support disabled")
+
+
+# decorator to disable functions if psycopg2 is not available
+def psycopg2_available(func):
+
+    def pass_through(*args, **kwargs):
+        if psycopg2 is None:
+            raise NotImplementedError("psycopg2 is not available")
+        return func(*args, **kwargs)
+
+    return pass_through
+
+
+@psycopg2_available
+def enable_cartridge(config):
+    conn = utils.connect(config)
+    curs = conn.cursor()
+    curs.execute("create extension if not exists rdkit")
+
+
+@psycopg2_available
+def disable_cartridge(config):
+    conn = utils.connect(config)
+    curs = conn.cursor()
+    curs.execute("drop extension if exists rdkit")
+
+
+@psycopg2_available
+def populate_rdkit_schema(config, force=False):
+    if not force:
+        print("This will destroy any existing information in the rdkit schema")
+        response = input("  are you sure? [yes/no]: ")
+        if response != 'yes':
+            print("cancelled")
+            return False
+
+    enable_cartridge(config)
+    conn = utils.connect(config)
+    curs = conn.cursor()
+    rdkit_schema_name = config.get('rdkit_schema', 'rdk')
+    lwreg_schema_name = config.get('lwregSchema', 'public')
+    if not lwreg_schema_name:
+        lwreg_schema_name = 'public'
+    curs.execute(f"create schema if not exists {rdkit_schema_name}")
+    curs.execute(f"drop table if exists {rdkit_schema_name}.mols cascade")
+    curs.execute(
+        f"select molregno, mol_from_ctab(molblock::cstring,false) m into {rdkit_schema_name}.mols from {lwreg_schema_name}.molblocks"
+    )
+    curs.execute(
+        f'create index {rdkit_schema_name}_molidx on {rdkit_schema_name}.mols using gist(m)'
+    )
+    curs.execute(
+        f'''CREATE OR REPLACE FUNCTION {rdkit_schema_name}_copy_new_mol() RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    INSERT INTO
+        {rdkit_schema_name}.mols(molregno,m)
+        VALUES(new.molregno,mol_from_ctab(new.molblock::cstring,false));
+           RETURN new;
+END;
+$BODY$
+language plpgsql;''')
+    curs.execute(
+        f'''CREATE OR REPLACE TRIGGER {lwreg_schema_name}_mol_insert_trigger
+     AFTER INSERT ON {lwreg_schema_name}.molblocks
+     FOR EACH ROW
+     EXECUTE FUNCTION {rdkit_schema_name}_copy_new_mol();''')
+    conn.commit()
+    return True

--- a/lwreg/test_dbutils.py
+++ b/lwreg/test_dbutils.py
@@ -31,12 +31,21 @@ if psycopg2:
     cfg['dbtype'] = 'postgresql'
     try:
         cn = utils.connect(config=cfg)
+        curs = cn.cursor()
+        curs.execute(
+            "select * from pg_available_extensions where name='rdkitd'")
+        if not curs.fetchone():
+            rdkit_cartridge_present = False
+        else:
+            rdkit_cartridge_present = True
     except psycopg2.OperationalError:
         # server not running
         psycopg2 = None
+        rdkit_cartridge_present = False
 
 
-@unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
+@unittest.skipIf(psycopg2 is None or not rdkit_cartridge_present,
+                 "skipping postgresql tests")
 class TestCartridgePgSQL(unittest.TestCase):
     integrityError = psycopg2.errors.UniqueViolation if psycopg2 else None
 
@@ -77,7 +86,8 @@ class TestCartridgePgSQL(unittest.TestCase):
         curs = None
 
 
-@unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
+@unittest.skipIf(psycopg2 is None or not rdkit_cartridge_present,
+                 "skipping postgresql tests")
 class TestCartridgePgSQLWithSchema(TestCartridgePgSQL):
 
     def setUp(self):
@@ -87,7 +97,8 @@ class TestCartridgePgSQLWithSchema(TestCartridgePgSQL):
         self._config['lwregSchema'] = 'lwreg'
 
 
-@unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
+@unittest.skipIf(psycopg2 is None or not rdkit_cartridge_present,
+                 "skipping postgresql tests")
 class TestCartridgePgSQLWithRDKitSchema(TestCartridgePgSQL):
 
     def setUp(self):

--- a/lwreg/test_dbutils.py
+++ b/lwreg/test_dbutils.py
@@ -40,6 +40,12 @@ class TestCartridgePgSQL(unittest.TestCase):
         self._config['dbname'] = 'lwreg_tests'
         self._config['dbtype'] = 'postgresql'
 
+    def tearDown(self):
+        utils._initdb(config=self._config, confirm=True)
+        utils._clear_cached_connection()
+        self._config = None
+        return super().tearDown()
+
     def baseRegister(self):
         smis = ('CC[C@H](F)Cl', 'CC[C@@H](F)Cl', 'CCC(F)Cl', 'CC(F)(Cl)C')
         utils._initdb(config=self._config, confirm=True)

--- a/lwreg/test_dbutils.py
+++ b/lwreg/test_dbutils.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2025 Greg Landrum and other lwreg contributors
+# All rights reserved
+# This file is part of lwreg.
+# The contents are covered by the terms of the MIT license
+# which is included in the file LICENSE,
+import os
+import pwd
+import unittest
+import sqlite3
+import tempfile
+
+from rdkit import Chem
+
+try:
+    from . import utils
+    from . import db_utils
+except ImportError:
+    import utils
+    import db_utils
+
+try:
+    import psycopg2
+except ImportError:
+    psycopg2 = None
+if psycopg2:
+    # we have the connector for postgresql. Is there a server running?
+    cfg = utils.defaultConfig()
+    cfg['dbname'] = 'lwreg_tests'
+    #cfg['host'] = 'localhost'
+    cfg['dbtype'] = 'postgresql'
+    try:
+        cn = utils.connect(config=cfg)
+    except psycopg2.OperationalError:
+        # server not running
+        psycopg2 = None
+
+
+@unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
+class TestCartridgePgSQL(unittest.TestCase):
+    integrityError = psycopg2.errors.UniqueViolation if psycopg2 else None
+
+    def setUp(self):
+        self._config = utils.defaultConfig()
+        self._config['dbname'] = 'lwreg_tests'
+        self._config['dbtype'] = 'postgresql'
+
+    def baseRegister(self):
+        smis = ('CC[C@H](F)Cl', 'CC[C@@H](F)Cl', 'CCC(F)Cl', 'CC(F)(Cl)C')
+        utils._initdb(config=self._config, confirm=True)
+        for smi in smis:
+            utils.register(smiles=smi, config=self._config)
+        mols = [Chem.MolFromSmiles(x) for x in ('Cc1[nH]ncc1', 'Cc1n[nH]cc1')]
+        for mol in mols:
+            utils.register(mol=mol, config=self._config)
+
+    def testPopulateSchema(self):
+        self.baseRegister()
+        db_utils.populate_rdkit_schema(self._config, force=True)
+        conn = utils.connect(config=self._config)
+        curs = conn.cursor()
+        curs.execute("select count(*) from rdk.mols")
+        self.assertEqual(curs.fetchone()[0], 6)
+        curs = None
+
+        # make sure the trigger is there too:
+        utils.register(smiles='CCC[C@H](F)Cl', config=self._config)
+        curs = conn.cursor()
+        curs.execute("select count(*) from rdk.mols")
+        self.assertEqual(curs.fetchone()[0], 7)
+        curs = None
+
+
+@unittest.skipIf(psycopg2 is None, "skipping postgresql tests")
+class TestCartridgePgSQLWithSchema(TestCartridgePgSQL):
+
+    def setUp(self):
+        self._config = utils.defaultConfig()
+        self._config['dbname'] = 'lwreg_tests'
+        self._config['dbtype'] = 'postgresql'
+        self._config['lwregSchema'] = 'lwreg'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lwreg/test_dbutils.py
+++ b/lwreg/test_dbutils.py
@@ -3,11 +3,7 @@
 # This file is part of lwreg.
 # The contents are covered by the terms of the MIT license
 # which is included in the file LICENSE,
-import os
-import pwd
 import unittest
-import sqlite3
-import tempfile
 
 from rdkit import Chem
 

--- a/lwreg/test_dbutils.py
+++ b/lwreg/test_dbutils.py
@@ -33,7 +33,7 @@ if psycopg2:
         cn = utils.connect(config=cfg)
         curs = cn.cursor()
         curs.execute(
-            "select * from pg_available_extensions where name='rdkitd'")
+            "select * from pg_available_extensions where name='rdkit'")
         if not curs.fetchone():
             rdkit_cartridge_present = False
         else:

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -4,7 +4,6 @@
 # The contents are covered by the terms of the MIT license
 # which is included in the file LICENSE,
 import os
-import pwd
 import time
 from datetime import datetime, timedelta
 import unittest
@@ -469,6 +468,7 @@ M  END
         if self._config['dbtype'] == 'postgresql':
             return
         tmpfile = tempfile.NamedTemporaryFile()
+        tmpfile.close()
         lconfig = self._config.copy()
         if 'connection' in lconfig:
             del lconfig['connection']
@@ -1011,11 +1011,11 @@ class TestRegisterConformersPSQL(TestRegisterConformers):
 
     def setUp(self):
         super(TestRegisterConformersPSQL, self).setUp()
-        getlogin = lambda: pwd.getpwuid(os.getuid())[0]
+        #getlogin = lambda: pwd.getpwuid(os.getuid())[0]
         self._config['dbname'] = 'lwreg_tests'
         self._config['dbtype'] = 'postgresql'
         self._config['password'] = 'testpw'
-        self._config['user'] = getlogin()
+        #self._config['user'] = getlogin()
 
     def testNoSecretsInRegistrationMetadata(self):
         """Make sure initdb is not storing any secrets."""

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -1028,11 +1028,14 @@ class TestRegisterConformersPSQL(TestRegisterConformers):
     def testNoSecretsInConfig(self):
         """Make sure configure_from_database isn't retrieveing accidentaly stored secrets."""
         utils._initdb(config=self._config, confirm=True)
+        cfg = copy.deepcopy(self._config)
         with utils.connect(self._config).cursor() as cursor:
             for key in ('password', 'user'):
+                if key not in cfg:
+                    cfg[key] = 'test'
                 cursor.execute(
                     'insert into registration_metadata values (%s,%s);',
-                    (key, self._config[key]))
+                    (key, cfg[key]))
         config_from_database = utils.configure_from_database(
             dbname=self._config['dbname'], dbtype=self._config['dbtype'])
         self.assertFalse(

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ conda_deps =
 conda_channels =
     conda-forge
 commands = 
-    conda install -q -c conda-forge rdkit>=2023.03.1 postgresql psycopg2 tqdm
+    conda install -q -c conda-forge rdkit>=2023.03.1 rdkit-postgresql postgresql psycopg2 tqdm
     pip install .
     # init database cluster
     initdb -D /tmp/testingdb


### PR DESCRIPTION
Adds (optional) functionality for:
1. adding an rdkit postgresql cartridge instance and populating it from the molecule table. (inspired by this blog post: https://greglandrum.github.io/rdkit-blog/posts/2024-10-31-lwreg-and-the-cartridge.html). Needless to say, this only works when you're using postgresql as the backend.
2. a convenience function for converting a dictionary to JSON - recognizes a couple of common types and allows them to be easily encoded. This is useful for storing computational results or configuration in JSON or JSONB columns.

There are also tests for all the new stuff 