### PR TITLE
Enable opt out for connection caching

### DIFF
--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -258,8 +258,6 @@ def connect(config):
         _dbConnection = cn
     else:
         _dbConnection = None
-    else:
-        _dbConnection = None
     _dbConfig = config
     return cn
 

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -313,7 +313,6 @@ def _get_standardization_list(config):
         config = _configure(filename=config)
     sopts = _lookupWithDefault(config, 'standardization')
 
-    res = []
     if type(sopts) not in (list, tuple):
         sopts = (sopts, )
     return tuple(sopts)

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -256,6 +256,8 @@ def connect(config):
         _replace_placeholders = _replace_placeholders_noop
     if _lookupWithDefault(config, "cacheConnection"):
         _dbConnection = cn
+    else:
+        _dbConnection = None
     _dbConfig = config
     return cn
 

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -1029,7 +1029,7 @@ def query(config=None,
                 ), (chash, ))
             res = [tuple(x) for x in curs.fetchall()]
     
-    if not _lookupWithDefault(config, "cacheConfig"):
+    if not _lookupWithDefault(config, "cacheConnection"):
         _clear_cached_connection()
 
     if not no_verbose:

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -258,6 +258,8 @@ def connect(config):
         _dbConnection = cn
     else:
         _dbConnection = None
+    else:
+        _dbConnection = None
     _dbConfig = config
     return cn
 


### PR DESCRIPTION
Allow for opting out of the connection caching. No change in the default behavior.

Useful to prevent unused open connection when using the lwreg utility in longer python scripts without calling the private `_clear_cached_connection()`.