### PR TITLE
Feat/get all registry numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.egg-info/
 *.sqlt
 docs/build/
+build/

--- a/docs/source/additionalfunctionality.rst
+++ b/docs/source/additionalfunctionality.rst
@@ -4,4 +4,4 @@ Additional Functionality Reference
 ==================================
 
 .. autofunction:: lwreg.utils.configure_from_database
-.. autofunction:: lwreg.utils.get_all_registry_numbers
+.. autofunction:: lwreg.utils.get_all_identifiers

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -56,7 +56,7 @@ In that case, you should always start by retrieving the config from the database
   lwreg.bulk_register(config,ms[1::])
 
   # there should now be 4 molecules in the database
-  utils.get_all_registry_numbers(config)
+  utils.get_all_identifiers(config)
 
   # we can now query the database
   lwreg.query(smiles='Cc1[nH]ncc1[C@H](F)Cl')

--- a/lwreg/__init__.py
+++ b/lwreg/__init__.py
@@ -7,7 +7,7 @@
 # which is included in the file LICENSE,
 
 from .utils import initdb, register, query, retrieve, bulk_register, \
-    register_multiple_conformers, registration_counts, get_all_registry_numbers, \
+    register_multiple_conformers, registration_counts, get_all_identifiers, \
         configure_from_database, set_default_config, connect, standardize_mol, \
             RegistrationFailureReasons
 

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -62,7 +62,7 @@ class TestLWReg(unittest.TestCase):
         utils._initdb(config=self._config, confirm=True)
 
         self.assertEqual(utils.registration_counts(config=self._config), 0)
-        self.assertEqual(utils.get_all_registry_numbers(config=self._config),
+        self.assertEqual(utils.get_all_identifiers(config=self._config),
                          ())
 
         self.assertEqual(utils.register(smiles='CCC', config=self._config), 1)
@@ -94,7 +94,7 @@ class TestLWReg(unittest.TestCase):
             'sqlite3': (1, 2, 3, 4),
             'postgresql': (1, 2, 6, 7),
         }
-        self.assertEqual(utils.get_all_registry_numbers(config=self._config),
+        self.assertEqual(utils.get_all_identifiers(config=self._config),
                          expected[self._config['dbtype']])
 
     def testGetDelimiter(self):
@@ -754,7 +754,7 @@ class TestRegisterConformers(unittest.TestCase):
             'sqlite3': ((1, 1), (1, 2), (2, 3)),
             'postgresql': ((1, 1), (1, 2), (4, 4)),
         }
-        self.assertEqual(utils.get_all_registry_numbers(config=self._config),
+        self.assertEqual(utils.get_all_identifiers(config=self._config),
                          expected[self._config['dbtype']])
 
     def testNoConformers(self):

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -751,8 +751,8 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertEqual(utils.registration_counts(config=self._config),
                          (2, 3))
         expected = {
-            'sqlite3': (1, 2),
-            'postgresql': (1, 4),
+            'sqlite3': ((1, 1), (1, 2), (2, 3)),
+            'postgresql': ((1, 1), (1, 2), (4, 4)),
         }
         self.assertEqual(utils.get_all_registry_numbers(config=self._config),
                          expected[self._config['dbtype']])

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -18,6 +18,7 @@ from . import standardization_lib
 import logging
 from tqdm import tqdm
 import base64
+import warnings
 
 _violations = (sqlite3.IntegrityError, )
 try:
@@ -935,6 +936,31 @@ def get_all_identifiers(config=None):
         curs.execute(f'select molregno from {hashTableName}')
         res = curs.fetchall()
         return tuple(sorted(x[0] for x in res))
+    
+
+def get_all_registry_numbers(config=None):
+    """
+    Returns a tuple with all of the registry numbers (molregnos) in the database.
+
+    :param config: Configuration dictionary.
+    :return: A tuple with all of the registry numbers (molregnos) in the database.
+    """
+    warnings.warn(
+        "get_all_registry_numbers() is deprecated and will be removed in a future version. "
+        "Use get_all_identifiers() instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    if not config:
+        config = _configure()
+    elif isinstance(config, str):
+        config = _configure(filename=config)
+
+    cn = connect(config)
+    curs = cn.cursor()
+    curs.execute(f'select molregno from {hashTableName}')
+    res = curs.fetchall()
+    return tuple(sorted(x[0] for x in res))
 
 
 def query(config=None,

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -909,13 +909,14 @@ def registration_counts(config=None):
     return ret
 
 
-def get_all_registry_numbers(config=None):
+def get_all_identifiers(config=None):
     """
-    Returns a tuple with all of the registry numbers (molregnos) in the database.
-    If in conformer mode, it returns the list of all (molregno, conf_id) tuples.
+    Returns a tuple with all of the identifiers in the database.
+    If in molecule mode, it returns a tuple with all of the molregnos in the database.
+    If in conformer mode, it returns a tuple of all (molregno, conf_id) tuples in the database.
 
     :param config: Configuration dictionary.
-    :return: A tuple with all of the registry numbers (molregnos) in the database.
+    :return: A tuple with all of the identifiers in the database.
     """
     if not config:
         config = _configure()

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -912,6 +912,7 @@ def registration_counts(config=None):
 def get_all_registry_numbers(config=None):
     """
     Returns a tuple with all of the registry numbers (molregnos) in the database.
+    If in conformer mode, it returns the list of all (molregno, conf_id) tuples.
 
     :param config: Configuration dictionary.
     :return: A tuple with all of the registry numbers (molregnos) in the database.
@@ -921,11 +922,18 @@ def get_all_registry_numbers(config=None):
     elif isinstance(config, str):
         config = _configure(filename=config)
 
-    cn = connect(config)
-    curs = cn.cursor()
-    curs.execute(f'select molregno from {hashTableName}')
-    res = curs.fetchall()
-    return tuple(sorted(x[0] for x in res))
+    if _lookupWithDefault(config, "registerConformers"):
+        cn = connect(config)
+        curs = cn.cursor()
+        curs.execute(f'select molregno, conf_id from {conformersTableName}')
+        res = curs.fetchall()
+        return tuple(sorted((x[0], x[1]) for x in res))
+    else:
+        cn = connect(config)
+        curs = cn.cursor()
+        curs.execute(f'select molregno from {hashTableName}')
+        res = curs.fetchall()
+        return tuple(sorted(x[0] for x in res))
 
 
 def query(config=None,


### PR DESCRIPTION
When the database is in conformer mode, return (molregno, confid) tuples when calling get_all_identifiers.

get_all_registry_numbers still there with deprecation warning + not tested anymore