### PR TITLE
Fix/bulk register all confs

### DIFF
--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -830,8 +830,10 @@ class TestRegisterConformers(unittest.TestCase):
         self.assertEqual(len(set([mrn for mrn, _ in rres])), 2)
 
         utils._initdb(config=self._config, confirm=True)
-        with self.assertRaises(self.integrityError):
-            utils.bulk_register(mols=[mol, mol2], fail_on_duplicate=True, config=self._config)
+        rres = utils.bulk_register(mols=[mol, mol2, mol3], fail_on_duplicate=True, config=self._config)
+        self.assertEqual(len(rres), 21)
+        self.assertEqual(len(set(rres)), 21)
+        self.assertTrue(RegistrationFailureReasons.DUPLICATE in rres)
 
     def testConformerQuery(self):
         ''' querying using a molecule which has conformers '''

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -809,6 +809,30 @@ class TestRegisterConformers(unittest.TestCase):
                                                fail_on_duplicate=True,
                                                config=self._config)
 
+    def testBulkMultiConfMolecule(self):
+        utils._initdb(config=self._config, confirm=True)
+
+        mol = Chem.Mol(self._mol1)
+        mol2 = Chem.Mol(mol)
+        mol3 = Chem.Mol(self._mol3)
+        cids = rdDistGeom.EmbedMultipleConfs(mol, 10, randomSeed=0xf00d)
+        self.assertEqual(len(cids), 10)
+
+        cids = rdDistGeom.EmbedMultipleConfs(mol2, 10, randomSeed=0xf00d)
+        self.assertEqual(len(cids), 10)
+
+        cids = rdDistGeom.EmbedMultipleConfs(mol3, 10, randomSeed=0xf00d)
+        self.assertEqual(len(cids), 10)
+
+        rres = utils.bulk_register(mols=[mol, mol2, mol3], fail_on_duplicate=False, config=self._config)
+        self.assertEqual(len(rres), 30)
+        self.assertEqual(len(set(rres)), 20)
+        self.assertEqual(len(set([mrn for mrn, _ in rres])), 2)
+
+        utils._initdb(config=self._config, confirm=True)
+        with self.assertRaises(self.integrityError):
+            utils.bulk_register(mols=[mol, mol2], fail_on_duplicate=True, config=self._config)
+
     def testConformerQuery(self):
         ''' querying using a molecule which has conformers '''
         utils._initdb(config=self._config, confirm=True)

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -818,10 +818,11 @@ class TestRegisterConformers(unittest.TestCase):
 
         # make sure we can still fail on duplicate conformers:
         utils._initdb(config=self._config, confirm=True)
-        with self.assertRaises(self.integrityError):
+        self.assertIn(
+            RegistrationFailureReasons.DUPLICATE,
             utils.register_multiple_conformers(mol=mol,
                                                fail_on_duplicate=True,
-                                               config=self._config)
+                                               config=self._config))
 
     def testBulkMultiConfMolecule(self):
         utils._initdb(config=self._config, confirm=True)
@@ -1055,9 +1056,11 @@ class TestRegisterConformers(unittest.TestCase):
             pi = conf.GetAtomPosition(i)
             conf.SetAtomPosition(i, (pi.x + 0.5, pi.y - 0.3, pi.z + 1.5))
         cp.AddConformer(self._mol1.GetConformer(), assignId=True)
-        self.assertRaises(
-            self.integrityError, lambda: utils.register_multiple_conformers(
-                mol=cp, fail_on_duplicate=True, config=cfg))
+        self.assertIn(
+            RegistrationFailureReasons.DUPLICATE,
+            utils.register_multiple_conformers(mol=cp,
+                                               fail_on_duplicate=True,
+                                               config=cfg))
 
 
 @unittest.skipIf(psycopg is None, "skipping postgresql tests")

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -14,6 +14,7 @@ from rdkit.Chem import rdMolTransforms
 import random
 import copy
 import tempfile
+from itertools import chain
 
 try:
     from . import utils

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -739,8 +739,8 @@ class TestRegisterConformers(unittest.TestCase):
         random.shuffle(aorder)
         nmol = Chem.RenumberAtoms(self._mol1, aorder)
         expected = {
-            'sqlite3': ((1, 1), (1, 2), (1, 1), (2, 3)),
-            'postgresql': ((1, 1), (1, 2), (1, 1), (4, 4)),
+            'sqlite3': (((1, 1), ), ((1, 2), ), ((1, 1), ), ((2, 3), )),
+            'postgresql': (((1, 1), ), ((1, 2), ), ((1, 1), ), ((4, 4), )),
         }
         self.assertEqual(
             utils.bulk_register(mols=(self._mol1, self._mol2, nmol,
@@ -756,6 +756,20 @@ class TestRegisterConformers(unittest.TestCase):
         }
         self.assertEqual(utils.get_all_identifiers(config=self._config),
                          expected[self._config['dbtype']])
+        utils._initdb(config=self._config, confirm=True)
+        expected = {
+            'sqlite3': (((1, 1), ), ((1, 2), ),
+                        (RegistrationFailureReasons.DUPLICATE, ), ((2, 3), )),
+            'postgresql':
+            (((1, 1), ), ((1, 2), ), (RegistrationFailureReasons.DUPLICATE, ),
+             ((4, 4), )),
+        }
+        self.assertTrue(
+            utils.bulk_register(mols=(self._mol1, self._mol2, nmol,
+                                      self._mol3),
+                                fail_on_duplicate=True,
+                                config=self._config),
+            expected[self._config['dbtype']])
 
     def testNoConformers(self):
         utils._initdb(config=self._config, confirm=True)
@@ -824,22 +838,31 @@ class TestRegisterConformers(unittest.TestCase):
         cids = rdDistGeom.EmbedMultipleConfs(mol3, 10, randomSeed=0xf00d)
         self.assertEqual(len(cids), 10)
 
-        rres = utils.bulk_register(mols=[mol, mol2, mol3], fail_on_duplicate=False, config=self._config)
+        rres = utils.bulk_register(mols=[mol, mol2, mol3],
+                                   fail_on_duplicate=False,
+                                   config=self._config)
+        self.assertEqual(len(rres), 3)
+        rres = tuple(chain.from_iterable(rres))
         self.assertEqual(len(rres), 30)
         self.assertEqual(len(set(rres)), 20)
         self.assertEqual(len(set([mrn for mrn, _ in rres])), 2)
 
         utils._initdb(config=self._config, confirm=True)
-        rres = utils.bulk_register(mols=[mol, mol2, mol3], fail_on_duplicate=True, config=self._config)
-        self.assertEqual(len(rres), 21)
+        rres = utils.bulk_register(mols=[mol, mol2, mol3],
+                                   fail_on_duplicate=True,
+                                   config=self._config)
+        self.assertEqual(len(rres), 3)
+        rres = list(chain.from_iterable(rres))
+        self.assertEqual(len(rres), 30)
         self.assertEqual(len(set(rres)), 21)
-        self.assertTrue(RegistrationFailureReasons.DUPLICATE in rres)
+        self.assertEqual(rres.count(RegistrationFailureReasons.DUPLICATE), 10)
 
     def testConformerQuery(self):
         ''' querying using a molecule which has conformers '''
         utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol3),
                                      config=self._config)
+        regids = tuple(chain.from_iterable(regids))
         self.assertEqual(
             sorted(utils.query(mol=self._mol1, config=self._config)),
             [regids[0]])
@@ -861,7 +884,7 @@ class TestRegisterConformers(unittest.TestCase):
         utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
                                      config=self._config)
-
+        regids = tuple(chain.from_iterable(regids))
         res = utils.retrieve(ids=(regids[0], regids[2]), config=self._config)
         self.assertEqual(len(res), 2)
         self.assertTrue(regids[0] in res)
@@ -900,7 +923,7 @@ class TestRegisterConformers(unittest.TestCase):
         utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
                                      config=self._config)
-        mrns, cids = zip(*regids)
+        mrns, _ = zip(*chain.from_iterable(regids))
         self.assertEqual(
             sorted(utils.query(ids=mrns[0:1], config=self._config)), [(1, 1),
                                                                       (1, 2)])

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -827,14 +827,17 @@ class TestRegisterConformers(unittest.TestCase):
         utils._initdb(config=self._config, confirm=True)
 
         mol1 = Chem.Mol(self._mol1)
-        mol2 = Chem.Mol(self._mol1)
-        mol3 = Chem.Mol(self._mol3)
         cids = rdDistGeom.EmbedMultipleConfs(mol1, 10, randomSeed=0xf00d)
+        self.assertEqual(len(cids), 10)
+        
+        mol2 = Chem.Mol(self._mol1)
         cids = rdDistGeom.EmbedMultipleConfs(mol2, 10, randomSeed=0xf00d)
+        self.assertEqual(len(cids), 10)
+
+        mol3 = Chem.Mol(self._mol3)
         cids = rdDistGeom.EmbedMultipleConfs(mol3, 10, randomSeed=0xf00d)
         self.assertEqual(len(cids), 10)
-        self.assertEqual(len(cids), 10)
-        self.assertEqual(len(cids), 10)
+
         mols = (mol1, mol2, mol3)
         rres = utils.bulk_register(mols=mols,
                                    fail_on_duplicate=False,
@@ -861,7 +864,7 @@ class TestRegisterConformers(unittest.TestCase):
 
         # Check for the returned Failure cauases on the duplicate conformers
         self.assertEqual(set(rres[1]),
-                         {(RegistrationFailureReasons.DUPLICATE)})
+                         {RegistrationFailureReasons.DUPLICATE})
         self.assertEqual(
             list(rres[1]).count(RegistrationFailureReasons.DUPLICATE), 10)
 

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -3,14 +3,12 @@
 # This file is part of lwreg.
 # The contents are covered by the terms of the MIT license
 # which is included in the file LICENSE,
-import os
 import time
 from datetime import datetime, timedelta
 import unittest
 import sqlite3
 from rdkit import Chem
 from rdkit.Chem import rdDistGeom
-from rdkit.Chem import rdMolTransforms
 import random
 import copy
 import tempfile
@@ -63,8 +61,7 @@ class TestLWReg(unittest.TestCase):
         utils._initdb(config=self._config, confirm=True)
 
         self.assertEqual(utils.registration_counts(config=self._config), 0)
-        self.assertEqual(utils.get_all_identifiers(config=self._config),
-                         ())
+        self.assertEqual(utils.get_all_identifiers(config=self._config), ())
 
         self.assertEqual(utils.register(smiles='CCC', config=self._config), 1)
         self.assertEqual(utils.register(smiles='CCCO', config=self._config), 2)
@@ -804,7 +801,7 @@ class TestRegisterConformers(unittest.TestCase):
                                                   config=self._config)
         self.assertEqual(len(rres), 11)
         self.assertEqual(len(set(rres)), 10)
-        self.assertEqual(len(set([mrn for mrn, cid in rres])), 1)
+        self.assertEqual(len(set([mrn for mrn, _ in rres])), 1)
 
         # make sure we can add more conformers:
         mol2 = Chem.Mol(mol)
@@ -815,7 +812,7 @@ class TestRegisterConformers(unittest.TestCase):
                                                   config=self._config)
         self.assertEqual(len(rres), 10)
         self.assertEqual(len(set(rres)), 10)
-        self.assertEqual(len(set([mrn for mrn, cid in rres])), 1)
+        self.assertEqual(len(set([mrn for mrn, _ in rres])), 1)
 
         # make sure we can still fail on duplicate conformers:
         utils._initdb(config=self._config, confirm=True)

--- a/lwreg/test_lwreg.py
+++ b/lwreg/test_lwreg.py
@@ -12,7 +12,6 @@ from rdkit.Chem import rdDistGeom
 import random
 import copy
 import tempfile
-from itertools import chain
 
 try:
     from . import utils
@@ -754,6 +753,8 @@ class TestRegisterConformers(unittest.TestCase):
         }
         self.assertEqual(utils.get_all_identifiers(config=self._config),
                          expected[self._config['dbtype']])
+
+        # Check that FailureReason is returned when fail_on_duplicate=True
         utils._initdb(config=self._config, confirm=True)
         expected = {
             'sqlite3': (((1, 1), ), ((1, 2), ),
@@ -825,104 +826,110 @@ class TestRegisterConformers(unittest.TestCase):
     def testBulkMultiConfMolecule(self):
         utils._initdb(config=self._config, confirm=True)
 
-        mol = Chem.Mol(self._mol1)
-        mol2 = Chem.Mol(mol)
+        mol1 = Chem.Mol(self._mol1)
+        mol2 = Chem.Mol(self._mol1)
         mol3 = Chem.Mol(self._mol3)
-        cids = rdDistGeom.EmbedMultipleConfs(mol, 10, randomSeed=0xf00d)
-        self.assertEqual(len(cids), 10)
-
+        cids = rdDistGeom.EmbedMultipleConfs(mol1, 10, randomSeed=0xf00d)
         cids = rdDistGeom.EmbedMultipleConfs(mol2, 10, randomSeed=0xf00d)
-        self.assertEqual(len(cids), 10)
-
         cids = rdDistGeom.EmbedMultipleConfs(mol3, 10, randomSeed=0xf00d)
         self.assertEqual(len(cids), 10)
-
-        rres = utils.bulk_register(mols=[mol, mol2, mol3],
+        self.assertEqual(len(cids), 10)
+        self.assertEqual(len(cids), 10)
+        mols = (mol1, mol2, mol3)
+        rres = utils.bulk_register(mols=mols,
                                    fail_on_duplicate=False,
                                    config=self._config)
+
+        # Get one tuple of tuples per molecule
         self.assertEqual(len(rres), 3)
-        rres = tuple(chain.from_iterable(rres))
-        self.assertEqual(len(rres), 30)
-        self.assertEqual(len(set(rres)), 20)
-        self.assertEqual(len(set([mrn for mrn, _ in rres])), 2)
+
+        # Expect mol2 should return the same as mol1
+        self.assertEqual(rres[0], rres[1])
+
+        # Check the entries for every mol
+        for res in rres:
+            self.assertEqual(len(res), 10)
+            self.assertEqual(len(set(res)), 10)
+        self.assertEqual(len(set([mrn for res in rres for mrn, _ in res])), 2)
 
         utils._initdb(config=self._config, confirm=True)
-        rres = utils.bulk_register(mols=[mol, mol2, mol3],
+        rres = utils.bulk_register(mols=mols,
                                    fail_on_duplicate=True,
                                    config=self._config)
-        self.assertEqual(len(rres), 3)
-        rres = list(chain.from_iterable(rres))
-        self.assertEqual(len(rres), 30)
-        self.assertEqual(len(set(rres)), 21)
-        self.assertEqual(rres.count(RegistrationFailureReasons.DUPLICATE), 10)
+        for res in rres:
+            self.assertEqual(len(res), 10)
+
+        # Check for the returned Failure cauases on the duplicate conformers
+        self.assertEqual(set(rres[1]),
+                         {(RegistrationFailureReasons.DUPLICATE)})
+        self.assertEqual(
+            list(rres[1]).count(RegistrationFailureReasons.DUPLICATE), 10)
 
     def testConformerQuery(self):
         ''' querying using a molecule which has conformers '''
+        mols = (self._mol1, self._mol3)
+
         utils._initdb(config=self._config, confirm=True)
-        regids = utils.bulk_register(mols=(self._mol1, self._mol3),
-                                     config=self._config)
-        regids = tuple(chain.from_iterable(regids))
-        self.assertEqual(
-            sorted(utils.query(mol=self._mol1, config=self._config)),
-            [regids[0]])
+        regids = utils.bulk_register(mols=mols, config=self._config)
+
+        for i, m in enumerate(mols):
+            self.assertEqual(sorted(utils.query(mol=m, config=self._config)),
+                             [regids[i][0]])
+
         # matches topology, but not conformer
         self.assertEqual(
             sorted(utils.query(mol=self._mol2, config=self._config)), [])
-        self.assertEqual(
-            sorted(utils.query(mol=self._mol3, config=self._config)),
-            [regids[1]])
 
         # query with no conformer
         qm = Chem.Mol(self._mol1)
         qm.RemoveAllConformers()
         self.assertEqual(sorted(utils.query(mol=qm, config=self._config)),
-                         [regids[0][0]])
+                         [regids[0][0][0]])  # 1st mol, 1st conformer, mrn
 
     def testConformerRetrieve(self):
         ''' querying using a molecule which has conformers '''
         utils._initdb(config=self._config, confirm=True)
-        regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
-                                     config=self._config)
-        regids = tuple(chain.from_iterable(regids))
-        res = utils.retrieve(ids=(regids[0], regids[2]), config=self._config)
-        self.assertEqual(len(res), 2)
-        self.assertTrue(regids[0] in res)
-        self.assertTrue(regids[2] in res)
-        self.assertIn('M  END', res[regids[0]][0])
-        self.assertEqual(res[regids[0]][1], 'mol')
-        self.assertIn('M  END', res[regids[2]][0])
-        self.assertEqual(res[regids[2]][1], 'mol')
+        mols = (self._mol1, self._mol2, self._mol3)
+        regids = utils.bulk_register(mols=mols, config=self._config)
 
-        # query with just molregnos... then we get back the same thing as if we
-        # were not in conformer mode.
-        mrn0 = regids[0][0]
-        mrn2 = regids[2][0]
+        res = utils.retrieve(ids=(regids[0][0], regids[2][0]),
+                             config=self._config)
+        self.assertTrue(len(res), 2)
+        mrns = []
+        for i in (0, 2):
+            self.assertIn(regids[i][0], res)
+            self.assertIn('M  END', res[regids[i][0]][0])
+            self.assertIn('mol', res[regids[i][0]][1])
+            mrn = regids[i][0][0]
 
-        res = utils.retrieve(id=mrn0, config=self._config)
-        self.assertIn(mrn0, res)
-        self.assertIn('M  END', res[mrn0][0])
+            # Query with just molregno... excpect to get the same thing as if we
+            # were not in conformer mode.
+            mres = utils.retrieve(id=mrn, config=self._config)
+            self.assertIn(mrn, mres)
+            self.assertIn('M  END', mres[mrn][0])
+            mrns.append(mrn)
 
-        res = utils.retrieve(ids=(mrn0, mrn2), config=self._config)
-        self.assertEqual(len(res), 2)
-        self.assertTrue(mrn0 in res)
-        self.assertTrue(mrn2 in res)
-        self.assertIn('M  END', res[mrn0][0])
-        self.assertEqual(res[mrn0][1], 'mol')
-        self.assertIn('M  END', res[mrn2][0])
-        self.assertEqual(res[mrn2][1], 'mol')
+        res = utils.retrieve(ids=tuple(mrns), config=self._config)
+        self.assertTrue(len(res), 2)
+        for mrn in mrns:
+            self.assertIn(mrn, res)
+            self.assertIn('M  END', res[mrn][0])
+            self.assertEqual('mol', res[mrn][1])
 
-        res = utils.retrieve(ids=(mrn0, mrn2),
+        res = utils.retrieve(ids=tuple(mrns),
                              config=self._config,
                              as_hashes=True)
-        self.assertIn(mrn0, res)
-        self.assertIn(mrn2, res)
-        self.assertIn('fullhash', res[mrn0])
+        for mrn in mrns:
+            self.assertIn(mrn, res)
+            self.assertIn('fullhash', res[mrn])
 
     def testConformerQueryById(self):
         utils._initdb(config=self._config, confirm=True)
         regids = utils.bulk_register(mols=(self._mol1, self._mol2, self._mol3),
                                      config=self._config)
-        mrns, _ = zip(*chain.from_iterable(regids))
+
+        mrns = [entry[0] for molentry in regids for entry in molentry]
+
         self.assertEqual(
             sorted(utils.query(ids=mrns[0:1], config=self._config)), [(1, 1),
                                                                       (1, 2)])

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -886,7 +886,8 @@ def bulk_register(config=None,
                         mrn = mrns[smi]
                     confMrns.append(mrn)
                 if not len(res):
-                    return RegistrationFailureReasons.FILTERED
+                    res.append(RegistrationFailureReasons.FILTERED)
+                    continue
                 sMol = rc[0]
                 for i, conf in enumerate(sMol.GetConformers()):
                     if i in confsDone:

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -837,6 +837,8 @@ def bulk_register(config=None,
         f"select value from {registrationMetadataTableName} where key='rdkitVersion'"
     )
     def_rdkit_version_label = curs.fetchone()[0]
+
+    _registerConformers = _lookupWithDefault(config, "registerConformers")
     for mol in tqdm(mols, disable=not show_progress):
         if mol is None:
             res.append(RegistrationFailureReasons.PARSE_FAILURE)
@@ -847,7 +849,7 @@ def bulk_register(config=None,
                 escape = mol.GetProp(escape_property)
             else:
                 escape = None
-            if not _lookupWithDefault(config, "registerConformers"):
+            if not _registerConformers:
                 mrn, _ = _register_mol(
                     tpl,
                     escape,

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -723,7 +723,7 @@ def _register_multiple_conformers(tpl, escape, cn, curs, config,
                 res.append(RegistrationFailureReasons.DUPLICATE)
                 continue
             res.append((mrn, conf_id))
-    return res
+    return tuple(res)
 
 
 def register_multiple_conformers(config=None,

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -676,6 +676,59 @@ def register(config=None,
     return res
 
 
+def _register_multiple_conformers(tpl, escape, cn, curs, config,
+                                  fail_on_duplicate):
+    # start by registering the first conformer in order to
+    # get the molregno that we'll use later
+    mrns = {}
+    rc = []
+    smiToCache = {}
+    res = []
+    for conf in tpl.mol.GetConformers():
+        Chem.AssignStereochemistryFrom3D(tpl.mol, conf.GetId())
+        smi = Chem.MolToSmiles(tpl.mol)
+        if smi not in mrns:
+            try:
+                mrn, conf_id = _register_mol(tpl,
+                                             escape,
+                                             cn,
+                                             curs,
+                                             config,
+                                             fail_on_duplicate,
+                                             confId=conf.GetId(),
+                                             molCache=rc)
+            except _violations:
+                res.append(RegistrationFailureReasons.DUPLICATE)
+                continue
+            except:
+                res.append(RegistrationFailureReasons.PARSE_FAILURE)
+                continue
+            if mrn is None:
+                res.append(RegistrationFailureReasons.FILTERED)
+                continue
+            mrns[smi] = mrn
+            smiToCache[smi] = len(rc) - 1
+            res.append((mrn, conf_id))
+        else:
+            sMol = rc[smiToCache[smi]]
+            mrn = mrns[smi]
+            molb = Chem.MolToV3KMolBlock(sMol, confId=conf.GetId())
+            try:
+                conf_id = _register_one_conformer(mrn,
+                                                  sMol,
+                                                  molb,
+                                                  cn,
+                                                  curs,
+                                                  config,
+                                                  fail_on_duplicate,
+                                                  confId=conf.GetId())
+            except _violations:
+                res.append(RegistrationFailureReasons.DUPLICATE)
+                continue
+            res.append((mrn, conf_id))
+    return res
+
+
 def register_multiple_conformers(config=None,
                                  mol=None,
                                  escape=None,
@@ -692,11 +745,6 @@ def register_multiple_conformers(config=None,
     :return: A tuple of (molregno, conf_id) for each conformer registered.
 
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
     if not _lookupWithDefault(config, "registerConformers"):
         raise ValueError(
@@ -709,52 +757,12 @@ def register_multiple_conformers(config=None,
 
     cn = connect(config)
     curs = cn.cursor()
-
-    # start by registering the first conformer in order to
-    # get the molregno that we'll use later
-    rc = []
-    mrns = {}
-    confsDone = set()
-    confMrns = []
-    res = []
-    for i, conf in enumerate(tpl.mol.GetConformers()):
-        Chem.AssignStereochemistryFrom3D(tpl.mol, conf.GetId())
-        smi = Chem.MolToSmiles(tpl.mol)
-        if smi not in mrns:
-            mrn, conf_id = _register_mol(tpl,
-                                         escape,
-                                         cn,
-                                         curs,
-                                         config,
-                                         fail_on_duplicate,
-                                         confId=conf.GetId(),
-                                         molCache=rc)
-            if mrn is not None:
-                mrns[smi] = mrn
-                confsDone.add(i)
-                res.append((mrn, conf_id))
-        else:
-            mrn = mrns[smi]
-        confMrns.append(mrn)
-    if not len(res):
-        return RegistrationFailureReasons.FILTERED
-
-    sMol = rc[0]
-    for i, conf in enumerate(sMol.GetConformers()):
-        if i in confsDone:
-            # we already registered the first conformer
-            continue
-        molb = Chem.MolToV3KMolBlock(sMol, confId=conf.GetId())
-        mrn = confMrns[i]
-        conf_id = _register_one_conformer(mrn,
-                                          sMol,
-                                          molb,
-                                          cn,
-                                          curs,
-                                          config,
-                                          fail_on_duplicate,
-                                          confId=conf.GetId())
-        res.append((mrn, conf_id))
+    res = _register_multiple_conformers(tpl=tpl,
+                                        escape=escape,
+                                        cn=cn,
+                                        curs=curs,
+                                        config=config,
+                                        fail_on_duplicate=fail_on_duplicate)
     if not no_verbose:
         print(res)
     return tuple(res)

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -762,7 +762,7 @@ def register_multiple_conformers(config=None,
                                         fail_on_duplicate=fail_on_duplicate)
     if not no_verbose:
         print(res)
-    return tuple(res)
+    return res
 
 
 def bulk_register(config=None,

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -215,10 +215,7 @@ def connect(config):
     global conformersTableName
     global lwregSchema
 
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
+    _check_config(config)
 
     cn = config.get('connection', None)
     if not cn and _dbConnection is not None and _dbConfig == config:
@@ -310,10 +307,7 @@ def _parse_mol(mol=None, molfile=None, molblock=None, smiles=None, config={}):
 
 
 def _get_standardization_list(config):
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
+    _check_config(config)
     sopts = _lookupWithDefault(config, 'standardization')
 
     if type(sopts) not in (list, tuple):
@@ -349,11 +343,6 @@ def standardize_mol(mol, config=None):
     Keyword arguments:
     config -- configuration dict
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     sopts = _get_standardization_list(config)
@@ -390,11 +379,6 @@ def hash_mol(mol, escape=None, config=None):
     escape -- the escape layer
     config -- configuration dict
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     layers = RegistrationHash.GetMolLayers(
@@ -661,12 +645,6 @@ def register(config=None,
     :raises RegistrationFailureReasons.PARSE_FAILURE: If molecule parsing fails.
     :raises RegistrationFailureReasons.FILTERED: If molecule is filtered out.
     """
-
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     tpl = _parse_mol(mol=mol,
@@ -806,12 +784,6 @@ def bulk_register(config=None,
     :param show_progress: If True, then a progress bar will be shown for the molecules.
     :return: A tuple containing the registry numbers or failure reasons for each molecule.
     """
-
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     if mols:
         pass
     elif sdfile:
@@ -935,10 +907,7 @@ def registration_counts(config=None):
     :param config: Configuration dictionary.
     :return: either the number of molecule in the database or a 2-tuple withe (number of molecules, number of conformers).
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
+    _check_config(config)
 
     cn = connect(config)
     curs = cn.cursor()
@@ -963,11 +932,7 @@ def get_all_identifiers(config=None):
     :param config: Configuration dictionary.
     :return: A tuple with all of the identifiers in the database.
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
+    _check_config(config)
     if _lookupWithDefault(config, "registerConformers"):
         cn = connect(config)
         curs = cn.cursor()
@@ -994,11 +959,7 @@ def get_all_registry_numbers(config=None):
         "Use get_all_identifiers() instead.",
         DeprecationWarning,
         stacklevel=2)
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
+    _check_config(config)
     cn = connect(config)
     curs = cn.cursor()
     curs.execute(f'select molregno from {hashTableName}')
@@ -1033,11 +994,6 @@ def query(config=None,
     :raises ValueError: If ids are provided but registerConformers is not enabled.
     :return: List of registry numbers or list of (molregno, conf_id) tuples.
     """
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     if ids is not None:
@@ -1140,12 +1096,6 @@ def retrieve(config=None,
     :param bool no_verbose: If this is False, then the registry number will be printed.
     :return: A dictionary of (data, format) 2-tuples with molregnos as keys.
     """
-
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     registerConformers = _lookupWithDefault(config, "registerConformers")
@@ -1255,11 +1205,6 @@ def _initdb(config=None, confirm=False):
     """
     if not confirm:
         return
-    if not config:
-        config = _configure()
-    elif isinstance(config, str):
-        config = _configure(filename=config)
-
     _check_config(config)
 
     cn = connect(config)
@@ -1359,7 +1304,6 @@ def _check_config(config):
         is raised.
 
     '''
-
     if not config:
         config = _configure()
     elif isinstance(config, str):

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -700,9 +700,6 @@ def _register_multiple_conformers(tpl, escape, cn, curs, config,
             except _violations:
                 res.append(RegistrationFailureReasons.DUPLICATE)
                 continue
-            except:
-                res.append(RegistrationFailureReasons.PARSE_FAILURE)
-                continue
             if mrn is None:
                 res.append(RegistrationFailureReasons.FILTERED)
                 continue
@@ -851,9 +848,6 @@ def bulk_register(config=None,
 
             except _violations:
                 res.append(RegistrationFailureReasons.DUPLICATE)
-                continue
-            except:
-                res.append(RegistrationFailureReasons.PARSE_FAILURE)
                 continue
             if mrn is None:
                 mrn = RegistrationFailureReasons.FILTERED

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -824,12 +824,21 @@ def bulk_register(config=None,
             res.append(RegistrationFailureReasons.PARSE_FAILURE)
             continue
         tpl = _parse_mol(mol=mol, config=config)
-        try:
-            if escape_property is not None and mol.HasProp(escape_property):
-                escape = mol.GetProp(escape_property)
-            else:
-                escape = None
-            if not _registerConformers:
+        if escape_property is not None and mol.HasProp(escape_property):
+            escape = mol.GetProp(escape_property)
+        else:
+            escape = None
+        if _registerConformers:
+            res.append(
+                _register_multiple_conformers(
+                    tpl=tpl,
+                    escape=escape,
+                    cn=cn,
+                    curs=curs,
+                    config=config,
+                    fail_on_duplicate=fail_on_duplicate))
+        else:
+            try:
                 mrn, _ = _register_mol(
                     tpl,
                     escape,
@@ -840,53 +849,15 @@ def bulk_register(config=None,
                     def_rdkit_version_label=def_rdkit_version_label,
                     def_std_label=def_std_label)
 
-                if mrn is None:
-                    mrn = RegistrationFailureReasons.FILTERED
-                res.append(mrn)
-            else:
-                rc = []
-                mrns = {}
-                confsDone = set()
-                confMrns = []
-                for i, conf in enumerate(tpl.mol.GetConformers()):
-                    Chem.AssignStereochemistryFrom3D(tpl.mol, conf.GetId())
-                    smi = Chem.MolToSmiles(tpl.mol)
-                    if smi not in mrns:
-                        mrn, conf_id = _register_mol(tpl,
-                                                    escape,
-                                                    cn,
-                                                    curs,
-                                                    config,
-                                                    fail_on_duplicate,
-                                                    confId=conf.GetId(),
-                                                    molCache=rc)
-                        if mrn is not None:
-                            mrns[smi] = mrn
-                            confsDone.add(i)
-                            res.append((mrn, conf_id))
-                    else:
-                        mrn = mrns[smi]
-                    confMrns.append(mrn)
-                if not len(res):
-                    res.append(RegistrationFailureReasons.FILTERED)
-                    continue
-                sMol = rc[0]
-                for i, conf in enumerate(sMol.GetConformers()):
-                    if i in confsDone:
-                        continue
-                    molb = Chem.MolToV3KMolBlock(sMol, confId=conf.GetId())
-                    mrn = confMrns[i]
-                    conf_id = _register_one_conformer(mrn,
-                                                    sMol,
-                                                    molb,
-                                                    cn,
-                                                    curs,
-                                                    config,
-                                                    fail_on_duplicate,
-                                                    confId=conf.GetId())
-                    res.append((mrn, conf_id))
-        except _violations:
-            res.append(RegistrationFailureReasons.DUPLICATE)
+            except _violations:
+                res.append(RegistrationFailureReasons.DUPLICATE)
+                continue
+            except:
+                res.append(RegistrationFailureReasons.PARSE_FAILURE)
+                continue
+            if mrn is None:
+                mrn = RegistrationFailureReasons.FILTERED
+            res.append(mrn)
     if not no_verbose:
         print(res)
     return tuple(res)

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -215,7 +215,7 @@ def connect(config):
     global conformersTableName
     global lwregSchema
 
-    _check_config(config)
+    config = _check_config(config)
 
     cn = config.get('connection', None)
     if not cn and _dbConnection is not None and _dbConfig == config:
@@ -307,7 +307,7 @@ def _parse_mol(mol=None, molfile=None, molblock=None, smiles=None, config={}):
 
 
 def _get_standardization_list(config):
-    _check_config(config)
+    config = _check_config(config)
     sopts = _lookupWithDefault(config, 'standardization')
 
     if type(sopts) not in (list, tuple):
@@ -343,7 +343,7 @@ def standardize_mol(mol, config=None):
     Keyword arguments:
     config -- configuration dict
     """
-    _check_config(config)
+    config = _check_config(config)
 
     sopts = _get_standardization_list(config)
     for sopt in sopts:
@@ -379,7 +379,7 @@ def hash_mol(mol, escape=None, config=None):
     escape -- the escape layer
     config -- configuration dict
     """
-    _check_config(config)
+    config = _check_config(config)
 
     layers = RegistrationHash.GetMolLayers(
         mol,
@@ -645,7 +645,7 @@ def register(config=None,
     :raises RegistrationFailureReasons.PARSE_FAILURE: If molecule parsing fails.
     :raises RegistrationFailureReasons.FILTERED: If molecule is filtered out.
     """
-    _check_config(config)
+    config = _check_config(config)
 
     tpl = _parse_mol(mol=mol,
                      molfile=molfile,
@@ -745,7 +745,7 @@ def register_multiple_conformers(config=None,
     :return: A tuple of (molregno, conf_id) for each conformer registered.
 
     """
-    _check_config(config)
+    config = _check_config(config)
     if not _lookupWithDefault(config, "registerConformers"):
         raise ValueError(
             'register_multiple_conformers can only be used when registerConformers is enabled'
@@ -803,7 +803,7 @@ def bulk_register(config=None,
     else:
         raise ValueError('No input molecules provided!')
 
-    _check_config(config)
+    config = _check_config(config)
 
     res = []
     cn = connect(config)
@@ -886,7 +886,7 @@ def registration_counts(config=None):
     :param config: Configuration dictionary.
     :return: either the number of molecule in the database or a 2-tuple withe (number of molecules, number of conformers).
     """
-    _check_config(config)
+    config = _check_config(config)
 
     cn = connect(config)
     curs = cn.cursor()
@@ -911,7 +911,7 @@ def get_all_identifiers(config=None):
     :param config: Configuration dictionary.
     :return: A tuple with all of the identifiers in the database.
     """
-    _check_config(config)
+    config = _check_config(config)
     if _lookupWithDefault(config, "registerConformers"):
         cn = connect(config)
         curs = cn.cursor()
@@ -938,7 +938,7 @@ def get_all_registry_numbers(config=None):
         "Use get_all_identifiers() instead.",
         DeprecationWarning,
         stacklevel=2)
-    _check_config(config)
+    config = _check_config(config)
     cn = connect(config)
     curs = cn.cursor()
     curs.execute(f'select molregno from {hashTableName}')
@@ -973,7 +973,7 @@ def query(config=None,
     :raises ValueError: If ids are provided but registerConformers is not enabled.
     :return: List of registry numbers or list of (molregno, conf_id) tuples.
     """
-    _check_config(config)
+    config = _check_config(config)
 
     if ids is not None:
         if not _lookupWithDefault(config, "registerConformers"):
@@ -1075,7 +1075,7 @@ def retrieve(config=None,
     :param bool no_verbose: If this is False, then the registry number will be printed.
     :return: A dictionary of (data, format) 2-tuples with molregnos as keys.
     """
-    _check_config(config)
+    config = _check_config(config)
 
     registerConformers = _lookupWithDefault(config, "registerConformers")
 
@@ -1184,7 +1184,7 @@ def _initdb(config=None, confirm=False):
     """
     if not confirm:
         return
-    _check_config(config)
+    config = _check_config(config)
 
     cn = connect(config)
     curs = cn.cursor()
@@ -1287,7 +1287,7 @@ def _check_config(config):
         config = _configure()
     elif isinstance(config, str):
         config = _configure(filename=config)
-
     if config.get("dbtype", "sqlite3") not in ('sqlite3', 'postgresql'):
         raise ValueError(
             "Possible values for dbtype are sqlite3 and postgresql")
+    return config

--- a/lwreg/utils.py
+++ b/lwreg/utils.py
@@ -737,7 +737,7 @@ def register_multiple_conformers(config=None,
     :param config: Configuration dictionary or filename.
     :param mol: RDKit molecule object (must have at least one conformer).
     :param escape: The escape layer.
-    :param fail_on_duplicate: If True, an exception is raised when trying to register a duplicate.
+    :param fail_on_duplicate: If True, ``RegistrationFailureReasons.DUPLICATE`` will be returned for each already-registered conformer, otherwise the already existing structure ID will be returned.
     :param no_verbose: If False, the registry number will be printed.
     :return: A tuple of (molregno, conf_id) for each conformer registered.
 


### PR DESCRIPTION
This PR achieves the following:

- Making sure that all conformers in all molecules are registerd in `bulk_register()` when the database is in conformer mode. A helper function `_register_multiple_conformers()` was added, that is now called from both `bulk_register` and `register_multiple_conformers()`

Behavior of registration function changes as follows:

- `register_multiple_conformers()` does not raise anymore when `fail_on_duplicate == True` but will add `RegistrationFailureReasons.DUPLICATE` to the returned identifiers in case the user tries to register an already registered conformer.
- The shape of the return value for `bulk_register()` changed when in conformer mode. Previously it would return a tuple of tuples (one per entry), the entries of a molecule are now grouped, so that it not returns get a tuple of tuples of tuples.

Code Cleanup:
- Code duplication together with the use of `_check_config()` was removed.
- Minimal on the way code clean up in `test_lwreg.py` 